### PR TITLE
Fix for #1 (cursor ends up before last char after clicking on the end of line decoration)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "frame-rainbow",
-  "version": "0.0.3",
+  "name": "frame-indent-rainbow",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "frame-rainbow",
-      "version": "0.0.3",
+      "name": "frame-indent-rainbow",
+      "version": "0.1.2",
       "license": "MIT",
       "devDependencies": {
         "@types/glob": "^8.1.0",
@@ -29,7 +29,7 @@
         "vscode-test": "^1.4.1"
       },
       "engines": {
-        "vscode": "^1.52.0"
+        "vscode": "^1.63.0"
       }
     },
     "node_modules/@esbuild/android-arm": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frame-indent-rainbow",
   "description": "Makes indentation easier to read by coloring frames around each indent level (block). Helpful for people with dyslexia.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publisher": "firejump",
   "author": {
     "name": "Bartosz Janiak"
@@ -9,7 +9,7 @@
   "icon": "assets/icon.png",
   "license": "MIT",
   "engines": {
-    "vscode": "^1.52.0"
+    "vscode": "^1.63.0"
   },
   "repository": {
     "url": "https://github.com/firejump/vscode-frame-rainbow.git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -345,8 +345,9 @@ class LineDecorationContext {
     const textDecoration: vscode.DecorationOptions = {
       range: new vscode.Range(startPos, endPos),
     };
-    const decoratorIndex = (tabDepth - 1) % this.builder.innerFrame.length;
-    this.builder.innerFrame[decoratorIndex].push(textDecoration);
+    // TODO rename
+    const decoratorIndex = (tabDepth - 1) % this.builder.outerFrame.length;
+    this.builder.outerFrame[decoratorIndex].push(textDecoration);
 
     if (endlineIndex !== this.text.length) {
       // We're attaching end of line decoration separately to the newline, rather than


### PR DESCRIPTION
https://github.com/firejump/vscode-frame-rainbow/issues/1

What is currently called "outer frame decorator" should actually be applied to the inner frame non-whitespace decoration as well. Otherwise both the text AND the newline character have additional after.contentText rendered. These decorations are effectively overlapping and thus click events can reach either one, resulting in the cursor being incorrectly put before the last character of the line in some cases.